### PR TITLE
FIX: Adds encoding for CORS Url builder to prevent empty results from API

### DIFF
--- a/src/components/episodes/EpisodesList.tsx
+++ b/src/components/episodes/EpisodesList.tsx
@@ -51,7 +51,7 @@ export const EpisodesList = () => {
         <Heading width="100%" my={0} p={4}>
           {error && "Episodes count not available"}
           {loading && "Loading"}
-          {!error && !loading && episodes.length}
+          {!error && !loading && `Episodes: ${episodes.length}`}
         </Heading>
       </Flex>
 

--- a/src/hooks/useEpisodes.ts
+++ b/src/hooks/useEpisodes.ts
@@ -22,7 +22,9 @@ export const useEpisodes = () => {
     urlWithParams.searchParams.set("limit", "20");
     urlWithParams.searchParams.set("country", "US");
 
-    return `https://api.allorigins.win/get?url=${urlWithParams}`;
+    return `https://api.allorigins.win/get?url=${encodeURIComponent(
+      urlWithParams.href
+    )}`;
   }, [pid]);
 
   const { podcasts_detail: storedPodcasts } = useStorageData();

--- a/src/hooks/useEpisodes.ts
+++ b/src/hooks/useEpisodes.ts
@@ -14,16 +14,16 @@ export const useEpisodes = () => {
 
   const { pid = "missing-podcast-id" } = useParams();
 
-  const encodedUrl = useMemo(() => {
-    const CORSUrl = new URL("https://itunes.apple.com/lookup?");
-    CORSUrl.searchParams.set("id", pid);
-    CORSUrl.searchParams.set("media", "podcast");
-    CORSUrl.searchParams.set("entity", "podcastEpisode");
-    CORSUrl.searchParams.set("limit", "20");
-    return CORSUrl;
-  }, [pid]);
+  const url = useMemo(() => {
+    const urlWithParams = new URL("https://itunes.apple.com/lookup?");
+    urlWithParams.searchParams.set("id", pid);
+    urlWithParams.searchParams.set("media", "podcast");
+    urlWithParams.searchParams.set("entity", "podcastEpisode");
+    urlWithParams.searchParams.set("limit", "20");
+    urlWithParams.searchParams.set("country", "US");
 
-  const url = `https://api.allorigins.win/get?url=${encodedUrl}`;
+    return `https://api.allorigins.win/get?url=${urlWithParams}`;
+  }, [pid]);
 
   const { podcasts_detail: storedPodcasts } = useStorageData();
   const podcastDetail = storedPodcasts?.find(
@@ -46,9 +46,9 @@ export const useEpisodes = () => {
         episodes: data,
       };
 
-      if (!hasStoredPodcasts) return [item] /* Init the storage data */;
+      if (!hasStoredPodcasts) return [item];
       else {
-        const payload = [...storedPodcasts]; /* Add the episode to current */
+        const payload = [...storedPodcasts];
         payload.push(item);
         return payload;
       }


### PR DESCRIPTION
## Summary
Seems that using the All Origins tool was preventing to get all the podcast episodes.
This PR fixes the issue
